### PR TITLE
NCIATWP-10312: add Fargate serverless workflows + infrastructure to master

### DIFF
--- a/.github/workflows/deploy-serverless-app.yml
+++ b/.github/workflows/deploy-serverless-app.yml
@@ -34,7 +34,7 @@ jobs:
       BACKEND_CONTAINER_PORT: 8000
       ECS_WEB_TASK_CPU_UNITS: 1024
       ECS_WEB_TASK_MEMORY_UNITS: 2048
-      S3_BUCKET: nci-cbiit-dceg-dev
+      S3_BUCKET: ${{ vars.S3_BUCKET }}
       TIER: ${{ inputs.tier }}
       CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
 

--- a/.github/workflows/deploy-serverless-app.yml
+++ b/.github/workflows/deploy-serverless-app.yml
@@ -1,0 +1,162 @@
+name: Deploy Serverless App
+
+# ECS Fargate application deployment: build images, register task def, deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Deploy environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - qa
+          - stage
+          - prod
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-app:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.tier }}
+    env:
+      APP: spatial-power
+      TZ: America/New_York
+      AWS_REGION: us-east-1
+      TASK_DEFINITION_TEMPLATE_PATH: .github/aws
+      WEB_CONTAINER_PORT: 80
+      BACKEND_CONTAINER_PORT: 8000
+      ECS_WEB_TASK_CPU_UNITS: 1024
+      ECS_WEB_TASK_MEMORY_UNITS: 2048
+      S3_BUCKET: nci-cbiit-dceg-dev
+      TIER: ${{ inputs.tier }}
+      CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
+
+    steps:
+      - uses: "actions/checkout@v6.0.2"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ env.CICD_ROLE_ARN }}
+          role-session-name: ${{ env.TIER }}-${{ env.APP }}-deploy-${{ github.ref_name }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set dynamic environment variables
+        run: |
+          TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+          REPO=${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_REGION.amazonaws.com/$APP
+          echo "IMAGE_REPOSITORY=$REPO" >> $GITHUB_ENV
+          echo "FRONTEND_IMAGE=$REPO:frontend-$TIMESTAMP" >> $GITHUB_ENV
+          echo "FRONTEND_IMAGE_LATEST=$REPO:frontend-latest" >> $GITHUB_ENV
+          echo "BACKEND_IMAGE=$REPO:backend-$TIMESTAMP" >> $GITHUB_ENV
+          echo "BACKEND_IMAGE_LATEST=$REPO:backend-latest" >> $GITHUB_ENV
+          echo "PARAMETER_PATH=/analysistools/${TIER}/${APP}" >> $GITHUB_ENV
+          echo "ENVIRONMENT_TIER=${TIER^^}" >> $GITHUB_ENV
+
+      - name: Retrieve SSM parameters
+        run: |
+          PARAMETER_PATH="/analysistools/${TIER}/${APP}"
+
+          declare -A PARAMS=(
+            ["ecs_cluster"]="ECS_CLUSTER"
+            ["ecs_web_task"]="ECS_WEB_TASK"
+            ["ecs_web_service"]="ECS_WEB_SERVICE"
+            ["role_arn"]="ROLE_ARN"
+          )
+
+          for ssm_name in "${!PARAMS[@]}"; do
+            env_var="${PARAMS[$ssm_name]}"
+            value=$(aws ssm get-parameter \
+              --name "${PARAMETER_PATH}/${ssm_name}" \
+              --with-decryption \
+              --query "Parameter.Value" \
+              --output text)
+            echo "${env_var}=${value}" >> $GITHUB_ENV
+            echo "Retrieved ${ssm_name} -> ${env_var}"
+          done
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2.1.0
+        with:
+          mask-password: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          file: docker/backend.dockerfile
+          pull: true
+          push: true
+          tags: |
+            ${{ env.BACKEND_IMAGE }}
+            ${{ env.BACKEND_IMAGE_LATEST }}
+          cache-from: type=registry,ref=${{ env.BACKEND_IMAGE_LATEST }}
+          cache-to: type=inline
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          file: docker/frontend.dockerfile
+          pull: true
+          push: true
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}
+            ${{ env.FRONTEND_IMAGE_LATEST }}
+          cache-from: type=registry,ref=${{ env.FRONTEND_IMAGE_LATEST }}
+          cache-to: type=inline
+
+      - name: Render task definition
+        run: |
+          envsubst < $TASK_DEFINITION_TEMPLATE_PATH/web.yml > web.yml
+
+          echo "=== Web Task Definition ==="
+          cat web.yml
+
+      - name: Register task definition
+        run: |
+          aws ecs register-task-definition --cli-input-yaml file://web.yml
+
+      - name: Update web service
+        run: |
+          aws ecs update-service \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_WEB_SERVICE }} \
+            --task-definition ${{ env.ECS_WEB_TASK }} \
+            --desired-count 1 \
+            --propagate-tags TASK_DEFINITION \
+            --force-new-deployment
+
+      - name: Wait for service stability
+        run: |
+          aws ecs wait services-stable \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_WEB_SERVICE }}
+
+      - name: Remove old task definitions
+        run: |
+          for family in "$ECS_WEB_TASK"; do
+              echo "Pruning old revisions for family: $family"
+              aws ecs list-task-definitions --family-prefix "$family" --sort DESC --query 'taskDefinitionArns[3:]' --output text \
+                  | xargs -n1 -r aws ecs deregister-task-definition --task-definition
+          done
+
+      - name: Deployment summary
+        run: |
+          echo "## Serverless Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **App:** ${{ env.APP }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tier:** ${{ env.TIER }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Frontend image:** ${{ env.FRONTEND_IMAGE }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Backend image:** ${{ env.BACKEND_IMAGE }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-serverless-ecr.yml
+++ b/.github/workflows/deploy-serverless-ecr.yml
@@ -1,0 +1,79 @@
+name: Deploy Serverless ECR
+
+# ECS Fargate ECR repository provisioning via AWS CDK
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Deploy environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - stage
+
+jobs:
+  deploy-ecr:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.tier }}
+    env:
+      AWS_REGION: us-east-1
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      TIER: ${{ inputs.tier }}
+      CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
+      CDK_DIR: infrastructure
+      CDK_EXEC: npx cdk
+      CDK_APP: npx ts-node bin/ecr.ts
+
+    steps:
+      - uses: "actions/checkout@v6.0.2"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ env.CICD_ROLE_ARN }}
+          role-session-name: ${{ env.TIER }}-spatial-power-ecr-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download env file from S3
+        run: |
+          aws s3 cp \
+            "s3://${{ vars.CICD_BUCKET }}/env/${{ env.TIER }}/spatial-power/cdk.env" \
+            "${{ env.CDK_DIR }}/cdk.env"
+
+      - name: Load CDK environment variables
+        working-directory: ${{ env.CDK_DIR }}
+        run: |
+          while IFS= read -r line || [ -n "$line" ]; do
+            case "$line" in ''|\#*) continue ;; esac
+            echo "$line" >> "$GITHUB_ENV"
+          done < cdk.env
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: "24"
+
+      - name: Install TypeScript dependencies
+        working-directory: ${{ env.CDK_DIR }}
+        run: npm ci
+
+      - name: CDK diff (preview changes)
+        working-directory: ${{ env.CDK_DIR }}
+        run: ${{ env.CDK_EXEC }} diff --app "${{ env.CDK_APP }}" || true
+
+      - name: CDK deploy
+        working-directory: ${{ env.CDK_DIR }}
+        run: ${{ env.CDK_EXEC }} deploy --app "${{ env.CDK_APP }}" --require-approval never
+
+      - name: Clean up env files
+        if: always()
+        working-directory: ${{ env.CDK_DIR }}
+        run: rm -f cdk.env

--- a/.github/workflows/deploy-serverless-infrastructure.yml
+++ b/.github/workflows/deploy-serverless-infrastructure.yml
@@ -1,0 +1,88 @@
+name: Deploy Serverless Infrastructure
+
+# ECS Fargate infrastructure provisioning via AWS CDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Environment to deploy to"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - qa
+          - stage
+          - prod
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-infrastructure:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.tier }}
+    env:
+      AWS_REGION: us-east-1
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      TIER: ${{ inputs.tier }}
+      CICD_ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/power-user-github-actions-cicd
+      CDK_DIR: infrastructure
+      CDK_EXEC: npx cdk
+      CDK_APP: npx ts-node bin/cdk.ts
+
+    steps:
+      - uses: "actions/checkout@v6.0.2"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ env.CICD_ROLE_ARN }}
+          role-session-name: ${{ env.TIER }}-spatial-power-infra-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download env file from S3
+        run: |
+          aws s3 cp \
+            "s3://${{ vars.CICD_BUCKET }}/env/${{ env.TIER }}/spatial-power/cdk.env" \
+            "${{ env.CDK_DIR }}/cdk.env"
+
+      - name: Load CDK environment variables
+        working-directory: ${{ env.CDK_DIR }}
+        run: |
+          while IFS= read -r line || [ -n "$line" ]; do
+            case "$line" in ''|\#*) continue ;; esac
+            echo "$line" >> "$GITHUB_ENV"
+          done < cdk.env
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: "24"
+
+      - name: Install TypeScript dependencies
+        working-directory: ${{ env.CDK_DIR }}
+        run: npm ci
+
+      - name: CDK diff (preview changes)
+        working-directory: ${{ env.CDK_DIR }}
+        run: ${{ env.CDK_EXEC }} diff --app "${{ env.CDK_APP }}" || true
+
+      - name: CDK deploy
+        working-directory: ${{ env.CDK_DIR }}
+        run: ${{ env.CDK_EXEC }} deploy --app "${{ env.CDK_APP }}" --require-approval never
+
+      - name: Clean up env files
+        if: always()
+        working-directory: ${{ env.CDK_DIR }}
+        run: rm -f cdk.env
+
+      - name: Deployment Summary
+        run: |
+          echo "## Serverless Infrastructure Deployment Complete!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment:** ${{ env.TIER }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Region:** ${{ env.AWS_REGION }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Registers the Fargate serverless pipeline on the default branch (`master`) so the `workflow_dispatch` "Run workflow" buttons appear and the input forms render correctly.

Brings the self-contained serverless set to `master`:
- Three `deploy-serverless-{ecr,infrastructure,app}.yml` workflows (TypeScript CDK; no `iac_language` toggle)
- `infrastructure/` TypeScript CDK (SQS work + error queues, ECS service, ALB target group/rule, autoscaling, SSM params) + `infrastructure/package-lock.json`
- `.github/aws/web.yml` task definition (frontend + backend + queue worker + FireLens→Datadog)
- `docker/backend-entrypoint.sh` (renders `config.json` from env)
- `docs/serverless-deployment-setup.md` runbook

The EC2 pipeline (`spatialpower-deploy.yml`) is untouched. Logs go to stdout → Datadog (no on-disk log files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
