### PR TITLE
NCIATWP-10312: 508 follow-up fixes (color-contrast, heading-markup, list marker, dup sentence)

### DIFF
--- a/client/src/pages/about/about.js
+++ b/client/src/pages/about/about.js
@@ -14,7 +14,7 @@ export function About() {
             <li><HashLink className='h6' smooth to='/about/#PowerAnalyses'>Power Analyses</HashLink></li>
             <li><HashLink className='h6' smooth to='/about/#Modules'>Modules</HashLink></li>
             <li>
-                <ol>
+                <ol style={{ listStyle: 'none' }}>
                     <li><HashLink className='h6' smooth to='/about/#sparrpowR'>sparrpowR</HashLink></li>
                 </ol>
             </li>

--- a/client/src/pages/calculate/input-form.js
+++ b/client/src/pages/calculate/input-form.js
@@ -307,7 +307,7 @@ export function InputForm({
 
     return <form className={className} onSubmit={handleSubmit} onReset={handleReset}>
         <fieldset className="border px-3 mb-4">
-            <legend className="legend font-weight-bold">Spatial Window</legend>
+            <legend className="legend font-weight-bold" role="heading" aria-level="2">Spatial Window</legend>
 
             <div className="form-group">
                 <div className="row col-md-24">
@@ -717,7 +717,7 @@ export function InputForm({
         </fieldset>
 
         <fieldset className="border px-3 mb-4">
-            <legend className="legend font-weight-bold">Sample Case</legend>
+            <legend className="legend font-weight-bold" role="heading" aria-level="2">Sample Case</legend>
             <div className="form-group">
                 <label htmlFor="samp_case" className="required">Case Type</label>
                 <OverlayTrigger overlay={<Tooltip id="samp_case_tooltip">Specify how case locations are randomized.</Tooltip>}>
@@ -816,7 +816,7 @@ export function InputForm({
         </fieldset>
 
         <fieldset className="border px-3 mb-4">
-            <legend className="legend font-weight-bold">Sample Control</legend>
+            <legend className="legend font-weight-bold" role="heading" aria-level="2">Sample Control</legend>
             <div className="form-group">
                 <label htmlFor="samp_control" className="required">Control Type</label>
                 <OverlayTrigger overlay={<Tooltip id="samp_control_tooltip">Specify how control locations are randomized.</Tooltip>}>
@@ -899,7 +899,7 @@ export function InputForm({
         </fieldset>
 
         <fieldset className="border px-3 mb-4">
-            <legend className="legend font-weight-bold">Simulations</legend>
+            <legend className="legend font-weight-bold" role="heading" aria-level="2">Simulations</legend>
             <div className="form-group">
                 <label htmlFor="sim_total" className="required">Number of Simulations</label>
                 <OverlayTrigger overlay={<Tooltip id="sim_total_tooltip">Specify the number of simulation iterations to perform.</Tooltip>}>
@@ -977,7 +977,7 @@ export function InputForm({
         </fieldset>
 
         <fieldset className="border px-3 mb-4">
-            <legend className="legend font-weight-bold">Queue</legend>
+            <legend className="legend font-weight-bold" role="heading" aria-level="2">Queue</legend>
             <div className="form-group custom-control custom-checkbox">
                 <input
                     type="checkbox"

--- a/client/src/pages/home/home.js
+++ b/client/src/pages/home/home.js
@@ -35,8 +35,6 @@ export function Home() {
             <p>
                 Spatial Power was developed by <a className='font-weight-bold' href='https://dceg.cancer.gov/fellowship-training/fellowship-experience/meet-fellows/oeeb/buller-ian' target='_blank' rel='noopener noreferrer'>Ian Buller</a> and <a className='font-weight-bold' href='https://dceg.cancer.gov/fellowship-training/fellowship-experience/meet-fellows/iteb/brown-derek' target='_blank' rel='noopener noreferrer'>Derek Brown</a> in collaboration with NCI's Center for Biomedical Informatics and Information Technology (CBIIT).
                 Support comes from the <a className='font-weight-bold' href='https://dceg.cancer.gov/' target='_blank' rel='noopener noreferrer'>Division of Cancer Epidemiology and Genetics</a> Informatics Tool Challenge and the <a className='font-weight-bold' href='https://cpfp.cancer.gov/' target='_blank' rel='noopener noreferrer'>Cancer Prevention Fellowship Program</a> Trans-Fellowship Research Award.
-                Support comes from the <a className='font-weight-bold' href='https://dceg.cancer.gov/' target='_blank' rel='noopener noreferrer'>Division of Cancer Epidemiology and Genetics</a> Informatics Tool Challenge and the <a className='font-weight-bold' href='https://cpfp.cancer.gov/' target='_blank' rel='noopener noreferrer'>Cancer Prevention Fellowship Program</a> Trans-Fellowship Research Award.
-
             </p>
             <p>
                 Questions or comments? Contact us via <a className='font-weight-bold' href='mailto:NCISpatialPowerWebAdmin@nih.gov?subject=Spatial Power'>email.</a>

--- a/client/src/styles/overrides.scss
+++ b/client/src/styles/overrides.scss
@@ -46,11 +46,11 @@ legend {
     color: white;
     &.active{
         color: #2e2e2e;
-        border-bottom-color: #14819B;
+        border-bottom-color: #117389;
         background-color: #F1F1F1;
     }
     &:hover{
-        color: #14819B;
+        color: #117389;
     }
 }
 


### PR DESCRIPTION
### Ticket
[NCIATWP-10312](https://tracker.nci.nih.gov/browse/NCIATWP-10312) (508 follow-ups on the 8461-satisfied baseline)

### Summary
Resolves the remaining axe findings on top of the 8461 accessibility baseline. Four small, surgical commits — no functional/behavioral changes:

- **color-contrast (WCAG 1.4.3, serious)** — active/hover nav tab teal `#14819B` → `#117389` in `overrides.scss` (4.0:1 → ~4.8:1 on `#F1F1F1`). Navbar-only.
- **heading-markup (WCAG 1.3.1)** — the 5 bold fieldset legends on the calculate form (Spatial Window, Sample Case, Sample Control, Simulations, Queue) now carry `role="heading" aria-level="2"`. The calculate page already has an `sr-only <h1>`, so order is valid (h1 → h2); no `page-has-heading-one` cascade.
- **sparrpowR list marker** — `about.js` sparrpowR item uses `<ol style={{ listStyle: 'none' }}>`: keeps the axe-valid `<ol><li>` structure from the 8461 list fix while hiding the stray visible "1." marker.
- **content cleanup** — removed an accidental duplicate "Support comes from the Division of Cancer Epidemiology and Genetics … Trans-Fellowship Research Award." sentence (and stray blank line) in the Home Credits paragraph. The duplication was introduced by afefc77 (Copilot autofix); master/stage have a single copy. One line restored, nothing else changed.

### Where to test
Deployed to **dev**: https://analysistools-dev.cancer.gov/spatial-power
- Home: active nav tab contrast passes; Credits sentence appears once.
- Calculate (sparrpowR): fieldset legends expose as level-2 headings.
- About: sparrpowR list item shows no leading "1." but remains a valid list.

### Other info
- Scope is `client/src` only (UI). No server/infra changes.
- Diff vs `stage` is now exclusively the 508 fixes (verified).
- Note (out of scope): with axe's **advanced** ruleset enabled, Home shows `css-focus-visible` from a pre-existing global `outline: none` in `overrides.scss` (present on stage too). Tracked separately — not in this PR.
