### PR TITLE
NCIATWP-10372: remediate critical/high container image CVEs

### DIFF
--- a/docker/backend.dockerfile
+++ b/docker/backend.dockerfile
@@ -12,10 +12,6 @@ RUN dnf -y update \
     udunits2 \
     && dnf clean all
 
-# Upgrade the globally-installed npm so its bundled deps (tar, minimatch,
-# brace-expansion) pick up security fixes.
-RUN npm install -g npm@latest
-
 ENV R_VER="4.5.3"
 ENV PATH="/opt/R/${R_VER}/bin:${PATH}"
 RUN ARCH=$(uname -m) \

--- a/docker/backend.dockerfile
+++ b/docker/backend.dockerfile
@@ -12,6 +12,10 @@ RUN dnf -y update \
     udunits2 \
     && dnf clean all
 
+# Upgrade the globally-installed npm so its bundled deps (tar, minimatch,
+# brace-expansion) pick up security fixes.
+RUN npm install -g npm@latest
+
 ENV R_VER="4.5.3"
 ENV PATH="/opt/R/${R_VER}/bin:${PATH}"
 RUN ARCH=$(uname -m) \

--- a/docker/frontend.dockerfile
+++ b/docker/frontend.dockerfile
@@ -1,13 +1,11 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+# ---- build stage: compile the React app (build-only deps stay here) ----
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS build
 
 RUN dnf -y update \
  && dnf -y install \
-    httpd \
     nodejs \
     npm \
  && dnf clean all
-
-RUN mkdir /client
 
 WORKDIR /client
 
@@ -17,8 +15,18 @@ RUN npm install
 
 COPY client /client/
 
-RUN npm run build \
- && mv /client/build /var/www/html/spatial-power
+RUN npm run build
+
+# ---- runtime stage: httpd serving the static build only (no node_modules/npm) ----
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+RUN dnf -y update \
+ && dnf -y install httpd \
+ && dnf clean all
+
+# Copy only the compiled static assets — build tooling never reaches the runtime
+# image, removing every build-time npm CVE (rollup, webpack, babel, etc.).
+COPY --from=build /client/build /var/www/html/spatial-power
 
 WORKDIR /var/www/html
 

--- a/server/package.json
+++ b/server/package.json
@@ -25,9 +25,14 @@
     "aws-sdk": "^2.1693.0",
     "compression": "^1.8.1",
     "express": "^4.22.1",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.1",
     "r-wrapper": "^1.1.2",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^4.7.1"
+  },
+  "overrides": {
+    "qs": "^6.14.0",
+    "brace-expansion": "^2.0.2",
+    "minimatch": "^9.0.6"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -33,6 +33,7 @@
   "overrides": {
     "qs": "^6.14.0",
     "brace-expansion": "^2.0.2",
-    "minimatch": "^9.0.6"
+    "minimatch": "^9.0.6",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
**Jira ticket: [NCIATWP-10372](https://tracker.nci.nih.gov/browse/NCIATWP-10372)**
**Dev UI: [analysistools-dev.cancer.gov/spatial-power](https://analysistools-dev.cancer.gov/spatial-power)**

### Ticket(s)
[NCIATWP-10372](https://tracker.nci.nih.gov/browse/NCIATWP-10372) — Container image vulnerability remediation (Twistlock / Prisma Cloud qa scan).

### Summary of changes
- **frontend.dockerfile → multi-stage build.** Build tooling + `node_modules` stay in the builder stage; the runtime image is a clean httpd serving only the compiled static assets. Removes every build-time npm CVE (rollup, webpack-dev-middleware, babel, loader-utils, html-minifier-terser, node-forge, …) from the shipped frontend image.
- **backend.dockerfile.** `npm install -g npm@latest` so the system npm's bundled deps (tar, minimatch, brace-expansion) pick up fixes.
- **server/package.json.** Bump `nodemailer` → `^9.0.1`; add CJS-safe `overrides` for transitive offenders (`qs`, `brace-expansion`, `minimatch`).

### Where the reviewer can test
After merge to `dev` and an image rebuild: smoke-test https://analysistools-dev.cancer.gov/spatial-power (UI loads; submit a calculation). **Then rebuild the images and re-run the Twistlock scan** to confirm Critical/High are cleared.

### Other info
- Dependency bumps are verified only by the rebuild + re-scan loop; residual findings with no upstream fix (e.g. `ip`, `lodash`, `html-minifier-terser`) are covered by the waiver doc in `~/Documents/AT/tickets/10312-spatial-power/`.
- Part of the **2.0.0 major** release — CAB approval required before the stage/prod promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
