### PR TITLE
NCIATWP-10372: bump qs override to ^6.15.2 (clears qs medium CVE-2026-8723)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -31,7 +31,7 @@
     "winston-daily-rotate-file": "^4.7.1"
   },
   "overrides": {
-    "qs": "^6.14.0",
+    "qs": "^6.15.2",
     "brace-expansion": "^2.0.2",
     "minimatch": "^9.0.6",
     "uuid": "^11.1.1"


### PR DESCRIPTION
**Jira ticket:** [NCIATWP-10372](https://tracker.nci.nih.gov/browse/NCIATWP-10372)
**Dev UI:** [analysistools-dev.cancer.gov/spatial-power](https://analysistools-dev.cancer.gov/spatial-power)

### Ticket(s)
[NCIATWP-10372](https://tracker.nci.nih.gov/browse/NCIATWP-10372) — follow-up to the merged container-CVE remediation (PR #34).

### Summary of changes
Bump the npm `qs` override `^6.14.0` → **`^6.15.2`** to clear the remaining `qs` **Medium** finding (CVE-2026-8723). The previous `^6.14.0` pin resolved to `6.14.2`, which is one CVE behind the fix in `6.15.2`. Net diff is a single line in `server/package.json`.

### Where the reviewer can test
After merge → `dev`/`qa` rebuild, re-run the Twistlock scan. **Verified** on a rebuilt dev image: `qs` is no longer flagged at all (version → `6.15.2`), backend Medium count `9 → 8`.

### Other info
- The Critical/High remediation already merged via PR #34; this only addresses the one fixable Medium.
- All remaining Medium/Low findings are platform-python or build-time-npm and are covered by the (updated) waiver doc in `~/Documents/AT/tickets/10312-spatial-power/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
