### PR TITLE
NCIATWP-10760 - Fix blank page when navigating between pages in Chrome

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -9,7 +9,9 @@ import './styles/main.scss';
 
 export function App() {
   const { pathname } = useLocation();
-  useEffect(_ => window.scrollTo(0, 0), [pathname]);
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
 
   const links = [
     {


### PR DESCRIPTION
[NCIATWP-10760](https://tracker.nci.nih.gov/browse/NCIATWP-10760)

A recent Chrome update (Chrome 150) broke navigation in Spatial Power: switching between nav-bar pages left a blank page until a hard refresh. This fixes the scroll-to-top effect so navigation works again in current Chrome.

- Updated the scroll-to-top effect in the app shell so it no longer returns a value, which Chrome 150's new scroll behavior turned into an invalid React cleanup that crashed the app on navigation